### PR TITLE
Make sorting more natural

### DIFF
--- a/src/LivewireModelTable.php
+++ b/src/LivewireModelTable.php
@@ -22,14 +22,13 @@ class LivewireModelTable extends Component
     {
         $this->sortField = array_key_exists('sort_field',
             $this->fields[$column]) ? $this->fields[$column]['sort_field'] : $this->fields[$column]['name'];
-        if (! $this->sortDir) {
-            $this->sortDir = 'asc';
-        } elseif ($this->sortDir == 'asc') {
+
+        if(! $this->sortDir || $this->sortDir == 'asc'){
             $this->sortDir = 'desc';
-        } else {
-            $this->sortDir = null;
-            $this->sortField = null;
+            return;
         }
+
+        $this->sortDir = 'asc';
     }
 
     protected function query()


### PR DESCRIPTION
Assume that query is sorted by ascending by default. Clicking the sort button should first change to `desc` and then toggle back to `asc`, `desc`, `asc`... etc. on subsequent clicks.