### PR TITLE
Select rows/all rows with checkboxes

### DIFF
--- a/src/Selectable.php
+++ b/src/Selectable.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Coryrose\LivewireTables;
+
+
+trait Selectable
+{
+    public $selected = [];
+
+    public $allRowsSelected = false;
+
+    public function selectAllRows($selected)
+    {
+        $this->query()->each(function ($row) use($selected) {
+            $this->selected[$row->id] = $selected;
+        });
+    }
+
+    public function selectRow($value, $id)
+    {
+        if ($value === false) {
+            $this->allRowsSelected = false;
+        }
+    }
+
+    public function clearSelected()
+    {
+        $this->allRowsSelected = false;
+
+        $this->selected = [];
+
+        $this->query()->each(function ($row) {
+            $this->selected[$row->id] = false;
+        });
+    }
+
+}

--- a/src/Selectable.php
+++ b/src/Selectable.php
@@ -12,7 +12,7 @@ trait Selectable
 
     public function selectAllRows($selected)
     {
-        $this->query()->each(function ($row) use($selected) {
+        $this->query()->each(function ($row) use ($selected) {
             $this->selected[$row->id] = $selected;
         });
     }

--- a/src/SelectableWithPagination.php
+++ b/src/SelectableWithPagination.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Coryrose\LivewireTables;
+
+
+use Livewire\WithPagination;
+
+trait SelectableWithPagination
+{
+    use WithPagination, Selectable;
+
+    public function previousPage()
+    {
+        $this->paginator['page'] = $this->paginator['page'] - 1;
+
+        $this->clearSelected();
+    }
+
+    public function nextPage()
+    {
+        $this->paginator['page'] = $this->paginator['page'] + 1;
+
+        $this->clearSelected();
+    }
+
+    public function gotoPage($page)
+    {
+        $this->paginator['page'] = $page;
+
+        $this->clearSelected();
+    }
+}

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -33,7 +33,7 @@ trait WithPagination
 
     private function clearSelectable()
     {
-        if(method_exists($this, 'clearSelected')){
+        if(method_exists($this, 'clearSelected')) {
             $this->clearSelected();
         }
     }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -4,30 +4,37 @@
 namespace Coryrose\LivewireTables;
 
 
-use Livewire\WithPagination;
+use Livewire\WithPagination as LivewireWithPagination;
 
-trait SelectableWithPagination
+trait WithPagination
 {
-    use WithPagination, Selectable;
+    use LivewireWithPagination;
 
     public function previousPage()
     {
         $this->paginator['page'] = $this->paginator['page'] - 1;
 
-        $this->clearSelected();
+        $this->clearSelectable();
     }
 
     public function nextPage()
     {
         $this->paginator['page'] = $this->paginator['page'] + 1;
 
-        $this->clearSelected();
+        $this->clearSelectable();
     }
 
     public function gotoPage($page)
     {
         $this->paginator['page'] = $page;
 
-        $this->clearSelected();
+        $this->clearSelectable();
+    }
+
+    private function clearSelectable()
+    {
+        if(method_exists($this, 'clearSelected')){
+            $this->clearSelected();
+        }
     }
 }


### PR DESCRIPTION
## Overview

This pr provides traits that:

1. Selecting of individual rows via checkbox
2. Selecting all the rows on the current page
3. When changing pages, deselect all rows.
4. When selecting all rows then deselecting a single row also deselect the "select all" checkbox.

## Example

![Kapture 2019-12-01 at 20 05 06](https://user-images.githubusercontent.com/20134485/69919559-08874280-1476-11ea-9121-d6f55f5d8460.gif)

## Blade

**Header, Select All Checkbox**
```
<input class="form-check-input"
   type="checkbox"
   wire:model="allRowsSelected"
   wire:change="selectAllRows($event.target.checked)"
>
```

**Row Checkbox, Select Row**
```
<input class="form-check-input"
       type="checkbox"
       value="{{ $row->id }}"
       wire:model="selected.{{ $row->id }}"
       wire:change="selectRow($event.target.checked, {{ $row->id }})"
>
```

## Still needs work

1. On sort, some kind of hook is needed to reset the select all.

2. Having the additional pagination trait is not ideal. It would be best if we can hook into page updates to run the `clearSelected` method but I am not sure if this is possible within livewire.

3. `selectRow` method currently just clears the select All checkbox via `allRowsSelected` because we have model binding in place for the `selected` array. Expect there is a better way to do this.
